### PR TITLE
pytiger.logging.config: new module to configure Python logging

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,7 @@ Release NEXT
 
 * New module: :mod:`pytiger.logging.syslog`
 * Set minimum Python interpreter version to 2.6
+* New module: :mod:`pytiger.logging.config`
 
 Release 1.1.1
 =============

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -4,6 +4,13 @@ Logging
 
 .. automodule:: pytiger.logging
 
+:mod:`pytiger.logging.config` -- Configure Python logging
+=========================================================
+
+.. automodule:: pytiger.logging.config
+   :synopsis: Configure the Python logging system following Tiger conventions
+   :members:
+
 :mod:`pytiger.logging.legacy` -- Legacy logging module
 ======================================================
 

--- a/src/pytiger/logging/config.py
+++ b/src/pytiger/logging/config.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2018  Tiger Computing Ltd
+# This file is part of pytiger and distributed under the terms
+# of a BSD-like license
+# See the file COPYING for details
+"""
+.. versionadded:: 1.2.0
+
+Configure the Python :mod:`logging` system following Tiger conventions.
+
+This module, combined with the Python :mod:`logging` package, is the
+spiritual successor to the deprecated :mod:`pytiger.logging.legacy` module.
+
+Example usage:
+
+>>> pytiger.logging.config.basic_config()
+>>> log = logging.getLogger(__name__)
+>>> log.warning('Unable to biggle')
+W: Unable to biggle
+>>> log.error('Abandon ship, all ye who run this')
+E: Abandon ship, all ye who run this
+"""
+
+from __future__ import absolute_import
+
+import logging
+
+from .syslog import SyslogFormatter, SyslogHandler
+
+
+#: Log format string following Tiger Computing conventions.
+TCL_FORMAT = "%(leveltag)s: %(message)s"
+
+
+class LevelTagFilter(object):
+    """
+    Log filter that adds the `leveltag` field.
+
+    This :class:`logging.Filter` sub-class (using duck-typing) is used to add
+    the `leveltag` field to :class:`logging.LogRecord` objects so that the tag
+    is available for use when formatted with the :const:`TCL_FORMAT` format
+    string.
+    """
+    def filter(self, record):
+        # Extract the first character of the level name
+        record.leveltag = record.levelname[0]
+
+        # We never actually filter messages out, just abuse filtering to add an
+        # extra field to the LogRecord
+        return True
+
+
+def basic_config(fmt=None, datefmt=None, level=None, stderr=True,
+                 stderr_level=None, syslog=True, syslog_level=None):
+    """
+    Perform basic configuration of the Python :mod:`logging` system.
+
+    This is very similar to :func:`logging.basicConfig` but designed to follow
+    Tiger Computing's logging conventions: messages are logged to stderr and to
+    syslog, and messages are prefixed with a single character tag describing
+    the log level.
+
+    This function does nothing if the root logger already has handlers
+    configured, therefore this function will only configure logging once. It is
+    a convenience method to do one-shot configuration of the Python logging
+    package.
+
+    The default behaviour is to:
+
+    * Create a :class:`logging.StreamHandler` which writes to
+      :data:`sys.stderr`.
+    * Create a :class:`pytiger.logging.syslog.SyslogHandler`, which forwards
+      messages to syslog using :func:`syslog.syslog`.
+    * Add the :class:`LevelTagFilter` to the above handlers.
+    * Set a formatter on the above handlers using the :const:`TCL_FORMAT`
+      format string.
+    * Add the handlers to the root logger.
+    * Sets the root logger's log level to :const:`logging.INFO`.
+
+    :param str fmt: Use the specified format string for the handlers.
+    :param str datefmt: Use the specified date/time format.
+    :param level: Set the root logger's log level.
+    :param bool stderr: Determine whether the stderr `StreamHandler` is
+                        configured or added to the root logger.
+    :param stderr_level: Set the stderr logger's log level.
+    :param bool syslog: Determine whether the `SyslogHandler` is
+                        configured or added to the root logger.
+    :param syslog_level: Set the syslog logger's log level.
+    """
+    root = logging.getLogger()
+
+    logging._acquireLock()
+    try:
+        # Do nothing if the root logger already has handlers configured
+        if len(root.handlers) == 0:
+            ltf = LevelTagFilter()
+
+            if fmt is None:
+                fmt = TCL_FORMAT
+
+            # Configure output to stderr if desired
+            if stderr:
+                h = logging.StreamHandler()
+                h.setFormatter(logging.Formatter(fmt, datefmt))
+                h.addFilter(ltf)
+
+                if stderr_level is not None:
+                    h.setLevel(stderr_level)
+
+                root.addHandler(h)
+
+            # Configure output to syslog if desired
+            if syslog:
+                h = SyslogHandler()
+                h.setFormatter(SyslogFormatter(fmt, datefmt))
+                h.addFilter(ltf)
+
+                if syslog_level is not None:
+                    h.setLevel(syslog_level)
+
+                root.addHandler(h)
+
+            # Set the standard log level threshold for the root logger
+            if level is None:
+                level = logging.INFO
+            root.setLevel(level)
+    finally:
+        logging._releaseLock()

--- a/src/pytiger/logging/legacy.py
+++ b/src/pytiger/logging/legacy.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 .. versionadded:: 1.0.0
+.. deprecated:: 1.2.0
 
 Defines a number of log level attributes and :class:`LegacySyslogger` to
 carry out the real work.
@@ -31,6 +32,7 @@ from __future__ import absolute_import
 import six
 import sys
 import syslog
+import warnings
 
 # Log levels
 ERROR = 0
@@ -51,6 +53,8 @@ class LegacySyslogger(object):
     An object that looks a bit like a Python logging object
     so that we can transition more easily later.
 
+    .. deprecated:: 1.2.0
+
     Example usage:
 
     >>> s = LegacySyslogger()
@@ -65,6 +69,8 @@ class LegacySyslogger(object):
     """
 
     def __init__(self):
+        warnings.warn('LegacySyslogger is deprecated', DeprecationWarning)
+
         # minimum log level to send
         self._log_level = DEBUG
         # log to stdout?

--- a/src/pytiger/logging/test_config.py
+++ b/src/pytiger/logging/test_config.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2015 Tiger Computing Ltd
+# This file is part of pytiger and distributed under the terms
+# of a BSD-like license
+# See the file COPYING for details
+
+from __future__ import absolute_import
+
+
+import logging
+import syslog
+import unittest
+from six import StringIO
+
+try:
+    from unittest.mock import call, patch
+except ImportError:
+    from mock import call, patch
+
+from .config import LevelTagFilter, basic_config
+
+
+class TestLevelTagFilter(unittest.TestCase):
+    def test_level_tag_filter(self):
+        out = StringIO()
+        h = logging.StreamHandler(out)
+        h.setFormatter(logging.Formatter(
+            '%(levelname)s:%(leveltag)s:%(name)s:%(message)s'))
+        h.addFilter(LevelTagFilter())
+        logging.getLogger().addHandler(h)
+        logging.warning('Could not frob; continuing')
+        out.seek(0)
+        self.assertEqual(out.getvalue(),
+                         'WARNING:W:root:Could not frob; continuing\n')
+
+
+class TestBasicConfig(unittest.TestCase):
+    def setUp(self):
+        # Clear the root logger's handlers otherwise basic_config() refuses to
+        # do anything. Test frameworks like Nose set up their own loggers so we
+        # have to work around that.
+        self.handlers = logging.root.handlers
+        logging.root.handlers = []
+
+    def tearDown(self):
+        for h in logging.root.handlers[:]:
+            if h not in self.handlers:
+                logging.root.removeHandler(h)
+
+        logging.root.handlers = self.handlers
+
+        super(TestBasicConfig, self).tearDown()
+
+    def _basic_config(self, **kwargs):
+        basic_config(**kwargs)
+
+        # Put the test framework's logging handlers back on the root handler so
+        # that we can get useful debugging information should the tests fail.
+        logging.root.handlers.extend(self.handlers)
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch('syslog.syslog')
+    def test_defaults(self, syslog_, stderr):
+        self._basic_config()
+
+        logging.warning('Unable to biggle')
+        logging.info('Could not frob; continuing')
+        logging.debug('Piffle!')
+
+        self.assertEqual(
+            stderr.getvalue(),
+            'W: Unable to biggle\nI: Could not frob; continuing\n')
+        calls = [
+            call(syslog.LOG_USER | syslog.LOG_WARNING,
+                 'W: Unable to biggle'),
+            call(syslog.LOG_USER | syslog.LOG_INFO,
+                 'I: Could not frob; continuing'),
+        ]
+        syslog_.assert_has_calls(calls)
+        self.assertEqual(syslog_.call_count, len(calls))
+
+    def test_already_configured(self):
+        h = logging.StreamHandler()
+        logging.root.addHandler(h)
+
+        self.assertEqual(logging.root.handlers, [h])
+
+        # Don't use self._basic_config() to avoid putting logging framework's
+        # handlers back on the root logger.
+        basic_config()
+
+        self.assertEqual(logging.root.handlers, [h])
+        self.assertTrue(logging.root.handlers[0] is h)
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch('syslog.syslog')
+    def test_format(self, syslog_, stderr):
+        self._basic_config(fmt='%(leveltag)s:%(name)s:%(message)s')
+
+        logging.warning('Unable to biggle')
+
+        self.assertEqual(stderr.getvalue(), 'W:root:Unable to biggle\n')
+        syslog_.assert_called_once_with(
+            syslog.LOG_USER | syslog.LOG_WARNING,
+            'W:root:Unable to biggle')
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch('syslog.syslog')
+    def test_stderr_disabled(self, syslog_, stderr):
+        self._basic_config(stderr=False)
+
+        logging.warning('Unable to biggle')
+
+        self.assertEqual(stderr.getvalue(), '')
+        syslog_.assert_called_once_with(
+            syslog.LOG_USER | syslog.LOG_WARNING,
+            'W: Unable to biggle')
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch('syslog.syslog')
+    def test_syslog_disabled(self, syslog_, stderr):
+        self._basic_config(syslog=False)
+
+        logging.warning('Unable to biggle')
+
+        self.assertEqual(stderr.getvalue(), 'W: Unable to biggle\n')
+        syslog_.assert_not_called()
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch('syslog.syslog')
+    def test_stderr_level(self, syslog_, stderr):
+        self._basic_config(stderr_level=logging.WARNING)
+
+        logging.warning('Unable to biggle')
+        logging.info('Could not frob; continuing')
+
+        self.assertEqual(stderr.getvalue(), 'W: Unable to biggle\n')
+        calls = [
+            call(syslog.LOG_USER | syslog.LOG_WARNING,
+                 'W: Unable to biggle'),
+            call(syslog.LOG_USER | syslog.LOG_INFO,
+                 'I: Could not frob; continuing'),
+        ]
+        syslog_.assert_has_calls(calls)
+        self.assertEqual(syslog_.call_count, len(calls))
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch('syslog.syslog')
+    def test_syslog_level(self, syslog_, stderr):
+        self._basic_config(syslog_level=logging.WARNING)
+
+        logging.warning('Unable to biggle')
+        logging.info('Could not frob; continuing')
+
+        self.assertEqual(
+            stderr.getvalue(),
+            'W: Unable to biggle\nI: Could not frob; continuing\n')
+        syslog_.assert_called_once_with(
+            syslog.LOG_USER | syslog.LOG_WARNING,
+            'W: Unable to biggle')
+
+    @patch('sys.stderr', new_callable=StringIO)
+    @patch('syslog.syslog')
+    def test_level(self, syslog_, stderr):
+        self._basic_config(level=logging.WARNING)
+
+        logging.warning('Unable to biggle')
+        logging.info('Could not frob; continuing')
+
+        self.assertEqual(
+            stderr.getvalue(),
+            'W: Unable to biggle\n')
+        syslog_.assert_called_once_with(
+            syslog.LOG_USER | syslog.LOG_WARNING,
+            'W: Unable to biggle')


### PR DESCRIPTION
Add a new module used to configure the Python logging framework following Tiger conventions. This module is the spiritual successor to the deprecated `pytiger.logging.legacy` module.